### PR TITLE
perf(core): Optimize image storage with WebP format

### DIFF
--- a/src/utils/cacheUtils.js
+++ b/src/utils/cacheUtils.js
@@ -6,14 +6,14 @@ import path from 'path';
 /**
  * Generate a filename for certification images based on URL parameters
  * @param {string} imageUrl - The certification image URL
- * @returns {string} Generated filename in format: id_oid_lastMod.png
+ * @returns {string} Generated filename in format: id_oid_lastMod.webp
  */
 export const getCertificationFileName = (imageUrl) => {
   const url = new URL(imageUrl);
   const id = url.searchParams.get('id');
   const oid = url.searchParams.get('oid');
   const lastMod = url.searchParams.get('lastMod');
-  return `${id}_${oid}_${lastMod}.png`;
+  return `${id}_${oid}_${lastMod}.webp`;
 };
 
 export const getImage = async (imageUrl, folder = 'images') => {

--- a/src/utils/generateImage.js
+++ b/src/utils/generateImage.js
@@ -400,7 +400,7 @@ export const generateImage = async (options) => {
 
           // Cache the cropped version for next time (non-blocking)
           try {
-            const croppedBuffer = logo.toBuffer('image/png');
+            const croppedBuffer = logo.toBuffer('image/webp', { lossless: true });
             const croppedFileName = getCertificationFileName(cert.logoUrl);
 
             // Upload cropped version (don't await - let it happen in background)


### PR DESCRIPTION
Convert cached certification images from PNG to WebP lossless format to reduce storage size and download times by ~30% while maintaining perfect image quality.

Changes:
- Update certification filename extension from .png to .webp
- Convert cropped certification buffer encoding to WebP lossless
- Keep final banner output as PNG for maximum compatibility

Expected performance improvements:
- ~30% reduction in blob storage size
- ~30% faster certification downloads from blob cache
- No quality loss (lossless mode ensures pixel-perfect images)