### PR TITLE
Change banner count query from estimated to exact

### DIFF
--- a/src/components/BannerCount.js
+++ b/src/components/BannerCount.js
@@ -29,7 +29,7 @@ const BannerCount = forwardRef((props, ref) => {
   const fetchCount = async () => {
     const { count: newCount, error } = await supabase
       .from('banners')
-      .select('id', { count: 'estimated', head: true })
+      .select('id', { count: 'exact', head: true })
       .eq('source_env', process.env.NEXT_PUBLIC_VERCEL_ENV ? process.env.NEXT_PUBLIC_VERCEL_ENV : 'development');
 
     if (error) {


### PR DESCRIPTION
## Summary
Updated the Supabase query in the BannerCount component to use exact row counts instead of estimated counts for improved accuracy.

## Changes
- Modified the `fetchCount` function in `src/components/BannerCount.js` to change the count strategy from `'estimated'` to `'exact'` when querying the banners table

## Details
This change ensures that the banner count displayed to users is accurate rather than approximate. While exact counts may have slightly higher latency compared to estimated counts, the accuracy improvement is beneficial for this use case where precise banner counts are important for the UI.

https://claude.ai/code/session_01JVjD9ztLQBbiZSK8x16YgJ