### PR TITLE
feat: add counters for Trailhead Community Stats

### DIFF
--- a/src/banner/api/queryBuilder.js
+++ b/src/banner/api/queryBuilder.js
@@ -9,6 +9,7 @@ import GET_TRAILHEAD_BADGES from '../../graphql/queries/getTrailheadBadges';
 import GET_MVP_STATUS from '../../graphql/queries/getMvpStatus';
 import GET_STAMPS from '../../graphql/queries/getStamps';
 import GET_AGENTBLAZER_RANK from '../../graphql/queries/getAgentblazerRank';
+import GET_COMMUNITY_STATS from '../../graphql/queries/getCommunityStats';
 import { calculateRequiredQueries } from '../../utils/queryDependencyCalculator';
 
 /**
@@ -80,6 +81,13 @@ export const QUERY_MAP = {
       slug: username,
       hasSlug: true,
       ...params,
+    }),
+  },
+  GET_COMMUNITY_STATS: {
+    query: GET_COMMUNITY_STATS,
+    url: 'https://community.api.trailhead.com/graphql',
+    buildVariables: (username) => ({
+      userSlug: username,
     }),
   },
 };

--- a/src/banner/components/counters.js
+++ b/src/banner/components/counters.js
@@ -3,7 +3,8 @@ import { drawBadgeCounter } from '../../utils/drawUtils.js';
 
 /**
  * Counter Badges Component
- * Renders badge counters (Badges, Superbadges, Certifications, Trails, Points, Stamps)
+ * Renders badge counters (Badges, Superbadges, Certifications, Trails, Points, Stamps,
+ * Answers, Best Answers, Questions, Followers, Following, Groups)
  */
 
 /**
@@ -14,6 +15,7 @@ import { drawBadgeCounter } from '../../utils/drawUtils.js';
  * @param {Object} data.certificationsData - Certifications data from API
  * @param {Object} data.rankData - Rank data (for trail count and points)
  * @param {Object} data.stampsData - Stamps data from API
+ * @param {Object} data.communityData - Community Q&A stats and connections from API
  * @param {Object} options - Component options
  * @param {Array<string>} options.counterOrder - Order of counters to display
  * @param {boolean} options.includeExpiredCertifications - Include expired certs in count
@@ -38,6 +40,12 @@ async function prepareCounters(data, options = {}) {
   const trailCount = data.rankData?.completedTrailCount || 0;
   const pointCount = getCounterPointText(data.rankData?.earnedPointsSum || 0);
   const stampCount = data.stampsData?.totalCount || 0;
+  const answerCount = data.communityData?.questionAndAnswersStats?.answersCount || 0;
+  const bestAnswerCount = data.communityData?.questionAndAnswersStats?.bestAnswersCount || 0;
+  const questionCount = data.communityData?.questionAndAnswersStats?.questionsCount || 0;
+  const followerCount = data.communityData?.communityConnections?.followers?.totalCount || 0;
+  const followingCount = data.communityData?.communityConnections?.following?.totalCount || 0;
+  const groupCount = data.communityData?.communityConnections?.groups?.totalCount || 0;
 
   // Define counter mapping
   const COUNTER_MAP = {
@@ -47,6 +55,12 @@ async function prepareCounters(data, options = {}) {
     trail: { data: trailCount, label: 'Trail', color: '#06482A' },
     point: { data: pointCount, label: 'Point', color: '#18477D' },
     stamp: { data: stampCount, label: 'Stamp', color: '#00B3A4' },
+    answer: { data: answerCount, label: 'Answer', color: '#C88000' },
+    'best-answer': { data: bestAnswerCount, label: 'Best Answer', color: '#F0B800' },
+    question: { data: questionCount, label: 'Question', color: '#9A6200' },
+    follower: { data: followerCount, label: 'Follower', color: '#E0357A' },
+    following: { data: followingCount, label: 'Following', color: '#B02860' },
+    group: { data: groupCount, label: 'Group', color: '#801D48' },
   };
 
   // Get counter configuration (scale and spacing)

--- a/src/banner/renderers/standardBanner.js
+++ b/src/banner/renderers/standardBanner.js
@@ -32,6 +32,7 @@ const RIGHT_PART_RATIO = 7 / 10;
  * @param {Object} data.mvpData - MVP data from API
  * @param {Object} data.agentblazerData - Agentblazer data from API
  * @param {Object} data.stampsData - Stamps data from API
+ * @param {Object} data.communityData - Community Q&A stats from API
  * @param {Object} options - Generation options
  * @returns {Promise<Object>} Banner result { bannerUrl, warnings, hash, timings }
  */

--- a/src/data/counters.json
+++ b/src/data/counters.json
@@ -34,5 +34,41 @@
     "label": "Stamp",
     "color": "#00B3A4",
     "defaultSelected": false
+  },
+  {
+    "id": "best-answer",
+    "label": "Best Answer",
+    "color": "#F0B800",
+    "defaultSelected": false
+  },
+  {
+    "id": "answer",
+    "label": "Answer",
+    "color": "#C88000",
+    "defaultSelected": false
+  },
+  {
+    "id": "question",
+    "label": "Question",
+    "color": "#9A6200",
+    "defaultSelected": false
+  },
+  {
+    "id": "follower",
+    "label": "Follower",
+    "color": "#E0357A",
+    "defaultSelected": false
+  },
+  {
+    "id": "following",
+    "label": "Following",
+    "color": "#B02860",
+    "defaultSelected": false
+  },
+  {
+    "id": "group",
+    "label": "Group",
+    "color": "#801D48",
+    "defaultSelected": false
   }
 ]

--- a/src/graphql/queries/getCommunityStats.js
+++ b/src/graphql/queries/getCommunityStats.js
@@ -1,0 +1,26 @@
+const GET_COMMUNITY_STATS = `
+  query GetQuestionsAnswersStatsAndConnections($userSlug: ID!) {
+    profileData(userSlug: $userSlug) {
+      communityUserId
+      questionAndAnswersStats {
+        answersCount
+        bestAnswersCount
+        communityUserRank
+        questionsCount
+      }
+      communityConnections {
+        followers {
+          totalCount
+        }
+        following {
+          totalCount
+        }
+        groups {
+          totalCount
+        }
+      }
+    }
+  }
+`;
+
+export default GET_COMMUNITY_STATS;

--- a/src/pages/api/banner/standard.js
+++ b/src/pages/api/banner/standard.js
@@ -75,6 +75,7 @@ export default async function handler(req, res) {
     const mvpData = responseMap.GET_MVP_STATUS?.data?.data?.profileData || {};
     const stampsData = responseMap.GET_STAMPS?.data?.data?.earnedStamps || {};
     const agentblazerData = responseMap.GET_AGENTBLAZER_RANK?.data?.data?.profile?.trailheadStats || {};
+    const communityData = responseMap.GET_COMMUNITY_STATS?.data?.data?.profileData || {};
 
     // Generate banner (call renderer directly)
     timings.start('image_generation');
@@ -87,6 +88,7 @@ export default async function handler(req, res) {
         mvpData,
         stampsData,
         agentblazerData,
+        communityData,
       },
       options
     );
@@ -128,6 +130,7 @@ export default async function handler(req, res) {
       mvpData,
       stampsData,
       agentblazerData,
+      communityData,
       timings: allTimings,
     };
     SupabaseUtils.updateBannerCounter(thb_data).catch((error) => {
@@ -143,6 +146,7 @@ export default async function handler(req, res) {
       mvpData,
       stampsData,
       agentblazerData,
+      communityData,
       imageUrl,
       warnings,
       infoMessages,

--- a/src/utils/queryDependencyCalculator.js
+++ b/src/utils/queryDependencyCalculator.js
@@ -69,6 +69,12 @@ const QUERY_DEPENDENCIES = {
     requiredWhen: ['displayAgentblazerRank'],
     params: {},
   },
+
+  GET_COMMUNITY_STATS: {
+    // Fetch community Q&A stats (answers, questions, best answers) & connections (followers, following, groups)
+    requiredWhenCounter: ['answer', 'best-answer', 'question', 'follower', 'following', 'group'],
+    params: {},
+  },
 };
 
 /**

--- a/src/utils/supabaseUtils.js
+++ b/src/utils/supabaseUtils.js
@@ -98,6 +98,7 @@ class SupabaseUtils {
             th_agentblazer: thb_data.learnerStatusLevels
               ? `${thb_data.learnerStatusLevels.statusName}-${thb_data.learnerStatusLevels.title}-${thb_data.learnerStatusLevels.edition}`
               : null,
+            th_community: thb_data.communityData,
             timings: originalTimings,
           },
         ]);
@@ -190,6 +191,14 @@ class SupabaseUtils {
               linkUrl: edge.node.linkUrl,
             },
           })) || [],
+      },
+      communityData: {
+        answers: data.communityData?.questionAndAnswersStats?.answersCount ?? null,
+        bestAnswers: data.communityData?.questionAndAnswersStats?.bestAnswersCount ?? null,
+        questions: data.communityData?.questionAndAnswersStats?.questionsCount ?? null,
+        followers: data.communityData?.communityConnections?.followers?.totalCount ?? null,
+        following: data.communityData?.communityConnections?.following?.totalCount ?? null,
+        groups: data.communityData?.communityConnections?.groups?.totalCount ?? null,
       },
     };
     return cleanedData;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded banner display capabilities with community Q&A and networking statistics. Users can now select and customize six new counters for their personalized banners: answers, best answers, questions, followers, following, and groups. These metrics provide enhanced visibility into community engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->