### PR TITLE
feat(core): add Sponsor sections in website and readme

### DIFF
--- a/.codesandbox/template.json
+++ b/.codesandbox/template.json
@@ -1,5 +1,5 @@
 {
-  "title": "Trailhead-Banner - Not Supported",
+  "title": "Trailhead Banner - Not Supported",
   "description": "This repository does not support CodeSandbox. Please clone the repository locally.",
   "published": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Claude Code Context - Trailhead-Banner
+# Claude Code Context - Trailhead Banner
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trailhead-Banner
+# Trailhead Banner
 
 ![Vercel](https://vercelbadge.vercel.app/api/nabondance/trailhead-banner)
 [![MegaLinter](https://github.com/nabondance/Trailhead-Banner/actions/workflows/mega-linter.yml/badge.svg)](https://github.com/nabondance/Trailhead-Banner/actions/workflows/mega-linter.yml)
@@ -23,6 +23,19 @@ Trailhead-Banner is a web application that allows users to generate LinkedIn ban
 - Display or hide various elements like badge count, superbadge count, rank logo, and certification count
 - Download the generated banner image
 - Responsive design
+
+## Powered by [Think2](https://think2.ai/trailhead-banner)
+
+A Salesforce partner focused on AI and founding sponsor of Trailhead Banner.
+Their sponsorship covers infrastructure costs and keeps this tool completely free — no ads, no cookies, no data selling.
+
+## Sponsors
+
+Thank you to everyone supporting this project ! [Become a sponsor](https://github.com/sponsors/nabondance)
+
+|                                                                                     |                                          |
+| ----------------------------------------------------------------------------------- | ---------------------------------------- |
+| [![nvuillam](https://github.com/nvuillam.png?size=40)](https://github.com/nvuillam) | [@nvuillam](https://github.com/nvuillam) |
 
 ## Thanks
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -4,6 +4,7 @@ import '../styles/globals.css';
 
 import TrailheadBannerHeader from '../components/TrailheadBannerHeader';
 import TrailheadBannerFooter from '../components/TrailheadBannerFooter';
+import Sponsors from '../components/Sponsors';
 
 import ThemeProvider from '../components/ThemeProvider';
 
@@ -146,6 +147,7 @@ export default function RootLayout({ children }) {
             <TrailheadBannerHeader />
           </header>
           <main>{children}</main>
+          <Sponsors />
           <TrailheadBannerFooter />
         </ThemeProvider>
       </body>

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useState, useRef, Suspense } from 'react';
-import dynamic from 'next/dynamic';
+import React, { useState, useRef } from 'react';
 import Image from 'next/image';
 import { generateIssueTitle, generateIssueBody } from '../utils/issueUtils';
 import LinkedInBannerTutorial from './LinkedInBannerTutorial';
@@ -10,11 +9,6 @@ import ProductionWarning from './ProductionWarning';
 import BannerCount from './BannerCount';
 import AnnouncementBanner from './AnnouncementBanner';
 import packageJson from '../../package.json';
-
-const PoweredByThink2 = dynamic(() => import('./PoweredByThink2'), {
-  loading: () => null,
-  ssr: false,
-});
 
 const MainPage = () => {
   const [imageUrl, setImageUrl] = useState('');
@@ -166,9 +160,6 @@ const MainPage = () => {
           <Image src={fullscreenImage} alt='Full Screen Example' layout='fill' objectFit='contain' unoptimized />
         </div>
       )}
-      <Suspense fallback={null}>
-        <PoweredByThink2 />
-      </Suspense>
     </div>
   );
 };

--- a/src/components/Sponsors.js
+++ b/src/components/Sponsors.js
@@ -1,0 +1,139 @@
+import React from 'react';
+import Image from 'next/image';
+import sponsors from '../data/sponsors.json';
+
+const MARQUEE_THRESHOLD = 4;
+
+const poweredBy = sponsors.filter((s) => s.tier === 'powered_by');
+const hallOfFame = sponsors.filter((s) => s.tier === 'hall_of_fame');
+const sponsorList = sponsors.filter((s) => s.tier === 'sponsor');
+const supporterList = sponsors.filter((s) => s.tier === 'supporter');
+
+const hasAnySponsor =
+  poweredBy.length > 0 || hallOfFame.length > 0 || sponsorList.length > 0 || supporterList.length > 0;
+
+const PoweredByCard = ({ sponsor }) => (
+  <a href={sponsor.url} target='_blank' rel='noopener noreferrer' className='powered-by-card'>
+    <Image src={sponsor.image} alt={sponsor.name} fill className='powered-by-bg' unoptimized />
+    <div className='powered-by-overlay'>
+      <span className='powered-by-name'>{sponsor.name}</span>
+      {sponsor.badge && <span className='powered-by-badge'>{sponsor.badge}</span>}
+    </div>
+  </a>
+);
+
+const HallOfFameCard = ({ sponsor }) => (
+  <a href={sponsor.url} target='_blank' rel='noopener noreferrer' className='hof-card'>
+    <Image src={sponsor.image} alt={sponsor.name} width={40} height={40} className='sponsor-avatar' unoptimized />
+    <div className='hof-info'>
+      <span className='hof-name'>{sponsor.name}</span>
+    </div>
+  </a>
+);
+
+const SponsorPill = ({ sponsor }) => (
+  <a href={sponsor.url} target='_blank' rel='noopener noreferrer' className='sponsor-pill'>
+    <Image src={sponsor.image} alt={sponsor.name} width={28} height={28} className='sponsor-avatar' unoptimized />
+    <span className='sponsor-pill-name'>{sponsor.name}</span>
+  </a>
+);
+
+const SupporterPill = ({ sponsor } = {}) => {
+  if (!sponsor?.url || !sponsor?.image) return null;
+  return (
+    <a href={sponsor.url} target='_blank' rel='noopener noreferrer' className='supporter-pill'>
+      <Image
+        src={sponsor.image}
+        alt={sponsor.name ?? ''}
+        width={20}
+        height={20}
+        className='sponsor-avatar'
+        unoptimized
+      />
+      <span className='supporter-pill-name'>@{sponsor.username ?? sponsor.name ?? ''}</span>
+    </a>
+  );
+};
+
+const MarqueeRow = ({ items = [], renderItem = () => null, keyFn = (s) => s } = {}) => {
+  const shouldScroll = items.length > MARQUEE_THRESHOLD;
+
+  if (!shouldScroll) {
+    return <div className='sponsors-row'>{items.map((s) => renderItem(s, keyFn(s)))}</div>;
+  }
+
+  return (
+    <div className='sponsors-marquee'>
+      <div className='sponsors-marquee-track'>
+        {items.map((s) => renderItem(s, `a-${keyFn(s)}`))}
+        {items.map((s) => renderItem(s, `b-${keyFn(s)}`))}
+      </div>
+    </div>
+  );
+};
+
+const Sponsors = () => {
+  if (!hasAnySponsor) return null;
+
+  return (
+    <div className='sponsors-section'>
+      <a
+        href='https://github.com/sponsors/nabondance'
+        target='_blank'
+        rel='noopener noreferrer'
+        className='sponsors-title'
+      >
+        Sponsors
+      </a>
+      <p className='sponsors-label'>
+        Trailhead Banner is free and open source. It exists thanks to the generosity of these supporters.
+      </p>
+
+      {poweredBy.length > 0 && (
+        <div className='sponsors-tier'>
+          <span className='sponsors-tier-label'>Powered by</span>
+          <div className='sponsors-row'>
+            {poweredBy.map((s) => (
+              <PoweredByCard key={s.name} sponsor={s} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {hallOfFame.length > 0 && (
+        <div className='sponsors-tier'>
+          <span className='sponsors-tier-label'>Hall of Fame</span>
+          <MarqueeRow
+            items={hallOfFame}
+            renderItem={(s, key) => <HallOfFameCard key={key} sponsor={s} />}
+            keyFn={(s) => s.name}
+          />
+        </div>
+      )}
+
+      {sponsorList.length > 0 && (
+        <div className='sponsors-tier'>
+          <span className='sponsors-tier-label'>Sponsors</span>
+          <MarqueeRow
+            items={sponsorList}
+            renderItem={(s, key) => <SponsorPill key={key} sponsor={s} />}
+            keyFn={(s) => s.username || s.name}
+          />
+        </div>
+      )}
+
+      {supporterList.length > 0 && (
+        <div className='sponsors-tier'>
+          <span className='sponsors-tier-label'>Supporters</span>
+          <MarqueeRow
+            items={supporterList}
+            renderItem={(s, key) => <SupporterPill key={key} sponsor={s} />}
+            keyFn={(s) => s.username || s.name}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Sponsors;

--- a/src/data/sponsors.json
+++ b/src/data/sponsors.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Think2",
+    "url": "https://think2.ai/trailhead-banner",
+    "image": "/assets/logos/think2-urls-5-large.svg",
+    "tier": "powered_by",
+    "badge": ""
+  },
+  {
+    "username": "nvuillam",
+    "name": "Nicolas Vuillamy",
+    "url": "https://github.com/nvuillam",
+    "image": "https://github.com/nvuillam.png",
+    "tier": "sponsor"
+  }
+]

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,7 +54,6 @@ body {
   --warning-color: #dd7a01;
   --error-color: #ba0517;
   --think2-yellow: #f2eb0a;
-  --think2-blue: #00b9b9;
   --tooltip-bg: #1f1f1f;
 }
 
@@ -80,7 +79,6 @@ body {
   --warning-color: #dd7a01;
   --error-color: #ba0517;
   --think2-yellow: #f2eb0a;
-  --think2-blue: #00b9b9;
   --tooltip-bg: #1f1f1f;
 }
 
@@ -1784,6 +1782,218 @@ select:focus {
   transition: transform 0.3s ease-in-out;
   position: relative;
   z-index: -1;
+}
+
+/* Sponsors Section */
+.sponsors-section {
+  max-width: min(800px, 100vw);
+  margin: 0 auto 16px;
+  padding: 16px;
+  text-align: center;
+}
+
+.sponsors-title {
+  display: inline-block;
+  font-size: 1.6em;
+  font-weight: bold;
+  color: var(--text-contrast);
+  margin: 0 0 6px;
+  text-decoration: none;
+}
+
+.sponsors-title:hover {
+  text-decoration: underline;
+}
+
+.sponsors-label {
+  font-size: 0.9em;
+  color: var(--text-contrast);
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+
+.sponsors-tier {
+  margin-top: 12px;
+  margin-bottom: 0;
+}
+
+.sponsors-tier-label {
+  display: block;
+  font-size: 0.62em;
+  font-weight: normal;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-faded);
+  margin-bottom: 3px;
+}
+
+.sponsors-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.sponsors-marquee {
+  overflow-x: hidden;
+  padding: 4px 0;
+  mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+}
+
+.sponsors-marquee-track {
+  display: flex;
+  width: max-content;
+  gap: 8px;
+  padding: 2px 0;
+  animation: sponsors-marquee 25s linear infinite;
+}
+
+.sponsors-marquee-track:hover {
+  animation-play-state: paused;
+}
+
+@keyframes sponsors-marquee {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sponsors-marquee-track {
+    animation: none;
+  }
+}
+
+/* Powered By card */
+.powered-by-card {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 4 / 1;
+  border-radius: 8px;
+  overflow: hidden;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.powered-by-card:hover {
+  transform: scale(1.02);
+}
+
+.powered-by-bg {
+  object-fit: cover;
+  object-position: center;
+}
+
+.powered-by-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: linear-gradient(to top, rgb(0 0 0 / 50%), rgb(0 0 0 / 0%) 60%);
+}
+
+.powered-by-name {
+  font-size: 1.1em;
+  font-weight: bold;
+  color: var(--think2-yellow);
+}
+
+.powered-by-badge {
+  font-size: 0.65em;
+  background: rgb(255 255 255 / 20%);
+  color: white;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid rgb(255 255 255 / 30%);
+}
+
+/* Hall of Fame card */
+.hof-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid gold;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+  background: rgb(255 215 0 / 5%);
+}
+
+.hof-card:hover {
+  transform: scale(1.04);
+}
+
+.hof-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.hof-name {
+  font-size: 0.85em;
+  font-weight: bold;
+  color: var(--text-contrast);
+}
+
+/* Sponsor pill */
+.sponsor-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.sponsor-pill:hover {
+  transform: scale(1.04);
+}
+
+.sponsor-pill-name {
+  font-size: 0.8em;
+  color: var(--text-contrast);
+}
+
+/* Supporter pill */
+.supporter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.supporter-pill:hover {
+  transform: scale(1.04);
+}
+
+.supporter-pill-name {
+  font-size: 0.75em;
+  color: var(--text-contrast);
+}
+
+/* Shared avatar */
+.sponsor-avatar {
+  border-radius: 50%;
 }
 
 .flipped-text {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sponsors section that displays tiered sponsor/supporter recognition with cards/pills and an animated marquee for larger lists.

* **Documentation**
  * Updated README with a "Powered by" mention and a "Sponsors" section including a sponsor call-to-action.

* **Chores**
  * Extended local settings to permit web fetches to github.com and think2.ai.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->