### PR TITLE
fix(deps): pin axios to 1.14.0 to mitigate supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@upstash/redis": "^1.37.0",
     "@vercel/blob": "^2.3.1",
     "@vercel/speed-insights": "^2.0.0",
-    "axios": "^1.13.6",
+    "axios": "1.14.0",
     "countup.js": "^2.10.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
@@ -79,7 +79,9 @@
       "ajv@6": "6.14.0",
       "ajv@8": "8.18.0",
       "undici": "6.24.1",
-      "flatted": "3.4.2"
+      "flatted": "3.4.2",
+      "axios@1.14.1": "1.14.0",
+      "axios@0.30.4": "0.30.3"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   ajv@8: 8.18.0
   undici: 6.24.1
   flatted: 3.4.2
+  axios@1.14.1: 1.14.0
+  axios@0.30.4: 0.30.3
 
 importers:
 
@@ -53,8 +55,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       axios:
-        specifier: ^1.13.6
-        version: 1.13.6
+        specifier: 1.14.0
+        version: 1.14.0
       countup.js:
         specifier: ^2.10.0
         version: 2.10.0
@@ -1035,8 +1037,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2116,8 +2118,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3424,11 +3427,11 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.13.6:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -4627,7 +4630,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
Axios versions 1.14.1 and 0.30.4 were compromised in a supply chain attack on 2026-03-31 that injected the malicious plain-crypto-js package as a RAT dropper. Pin to the safe 1.14.0 release and add pnpm overrides to block both malicious versions from being pulled in transitively.

References: https://socket.dev/blog/axios-npm-package-compromised

https://claude.ai/code/session_01LudKPyDZA8t3nfLmS3TRfS