### PR TITLE
feat(config): improve claude code setup

### DIFF
--- a/.claude/agents/graphql-explorer.md
+++ b/.claude/agents/graphql-explorer.md
@@ -2,7 +2,6 @@
 name: graphql-explorer
 description: Specialist for the Trailhead GraphQL API layer. Use when exploring, testing, debugging, or modifying queries in src/graphql/queries/, the cache layer (redisCacheUtils.js), the query builder (queryBuilder.js), or when you need to understand what data fields a query returns. Also use when diagnosing cache hits/misses or adding new data fields to the banner.
 tools: Bash, Read, Glob, Grep, WebFetch
-model: claude-sonnet-4-6
 ---
 
 # GraphQL Explorer

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -2,7 +2,6 @@
 name: security-reviewer
 description: Security specialist for Trailhead-Banner. Use when reviewing API routes, URL validation, input handling, or before merging changes that touch src/pages/api/, src/utils/imageValidation.js, src/utils/usernameValidation.js, or any code that fetches external URLs or processes user input.
 tools: Read, Glob, Grep, Bash
-model: claude-sonnet-4-6
 ---
 
 # Security Reviewer

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/SessionStart.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/PreCompact.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(bash .claude/skills/:*)",

--- a/.claude/skills/verify.sh
+++ b/.claude/skills/verify.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Verify skill - End-to-end verification: production build + banner generation
+# Usage: /verify [username ...]
+# Stops any running dev server (build clobbers .next), runs a production build,
+# starts a fresh dev server, tests banner generation per username, stops server.
+
+SKILLS_DIR="$(cd "$(dirname "$0")" && pwd)"
+USERNAMES=("$@")
+[ ${#USERNAMES[@]} -eq 0 ] && USERNAMES=(nabondance)
+
+# 1. Ensure no dev server is running (next build breaks a running dev server)
+if curl -s http://localhost:3000 > /dev/null 2>&1; then
+  echo "Dev server running — stopping it before build"
+  bash "$SKILLS_DIR/dev-stop.sh"
+fi
+
+# 2. Production build
+if ! bash "$SKILLS_DIR/build.sh"; then
+  echo "Verify: FAIL (build)"
+  exit 1
+fi
+
+# 3. Start dev server
+if ! bash "$SKILLS_DIR/dev-start.sh"; then
+  echo "Verify: FAIL (dev server did not start)"
+  exit 1
+fi
+
+# 4. Banner generation per username
+FAILURES=0
+for U in "${USERNAMES[@]}"; do
+  if ! bash "$SKILLS_DIR/img-test.sh" "$U"; then
+    echo "img-test ($U): FAILED"
+    FAILURES=$((FAILURES + 1))
+  fi
+done
+
+# 5. Stop dev server
+bash "$SKILLS_DIR/dev-stop.sh" > /dev/null 2>&1 || true
+echo "Dev server: Stopped"
+
+# Summary
+if [ "$FAILURES" -eq 0 ]; then
+  echo "Verify: PASS (build OK, ${#USERNAMES[@]} banner test(s) OK)"
+else
+  echo "Verify: FAIL ($FAILURES of ${#USERNAMES[@]} banner test(s) failed)"
+  exit 1
+fi

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: verify
+description: End-to-end verification - production build + banner generation tests (optional usernames, default nabondance)
+---
+
+# Verify
+
+Full end-to-end check that the current code works. Run before committing non-trivial changes.
+
+The script will:
+
+1. Stop any running dev server (a production build breaks a running dev server)
+2. Run the production build (`pnpm build`)
+3. Start a fresh dev server in background
+4. Test banner generation (POST /api/banner/standard) for each username (default: nabondance)
+5. Stop the dev server and print a PASS/FAIL summary
+
+Usage: `/verify` (default username) or `/verify <username> [username...]`
+
+Execute: `bash .claude/skills/verify.sh "$@"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,11 @@ Token-optimized commands available:
 - **`/dev-start`** - Start dev server in background (zero output, waits until ready)
 - **`/dev-stop`** - Stop background dev server (cleanup)
 - **`/img-test [username]`** - Test image generation API (requires dev server, default: nabondance)
+- **`/verify [username...]`** - Full end-to-end check: production build + banner generation tests (default: nabondance)
+
+## Verifying Changes
+
+Before committing non-trivial changes, run `/verify`. It stops any running dev server (a production build breaks it), runs `pnpm build`, starts a fresh dev server, generates a banner via `POST /api/banner/standard` for each username, stops the server, and prints `Verify: PASS` or `FAIL`. For a quick iteration loop instead, keep a dev server up (`/dev-start`) and use `/img-test`.
 
 ## Token-Saving References
 
@@ -184,193 +189,24 @@ Instead of asking for details, read these directly:
 - Component structure → `src/components/BannerForm.js`
 - Background configs → `src/data/banners.json`
 
+## Working Docs
+
+The `docs/` folder contains two kinds of documents:
+
+- **Feature notes** — plans, open questions, and migration steps for features currently in progress
+- **Reference guides** — e.g. `docs/banner-components.md`, the full guide for banner components
+
+Before starting work on an ongoing feature, look in `docs/` for an existing note about it.
+
 ---
 
 ## Banner Component Architecture
 
-### Banner Directory Structure
+Banner code lives in `src/banner/`: `components/` holds reusable parts (background, rankLogo, counters, certifications, superbadges, agentblazer, mvpRibbon, watermark), `renderers/` holds banner implementations (standardBanner.js).
 
-```text
-src/banner/
-├── components/        # Reusable components (background, logos, certifications)
-│   ├── background.js
-│   ├── rankLogo.js
-│   ├── counters.js
-│   ├── certifications.js
-│   ├── superbadges.js
-│   ├── agentblazer.js
-│   ├── mvpRibbon.js
-│   └── watermark.js
-└── renderers/         # Banner implementations (standard, rewind, future types)
-    └── standardBanner.js
-```
+Every component exports 4 functions: `prepare*` (async — load assets, compute layout), `render*` (draw to canvas), `get*Warnings`, `get*Timings`. Renderers follow 3 phases: **prepare** (components in parallel via `Promise.all`) → **render** (sequential, for correct layering) → **collect** warnings and encode to base64.
 
-### Component Contract
-
-All components follow this 4-function pattern:
-
-```javascript
-// 1. PREPARE - Load assets, calculate layout (async, runs in parallel)
-async function prepare*(data, options = {}, layout) {
-  // Load images, process data, calculate positions
-  return { /* prepared data, warnings, timings */ };
-}
-
-// 2. RENDER - Draw to canvas (sequential for correct layering)
-async function render*(ctx, prepared, x, y) {
-  ctx.drawImage(...);  // Draw using prepared data
-  return { render_ms: timeElapsed };
-}
-
-// 3. WARNINGS - Get any issues encountered
-function get*Warnings(prepared) {
-  return prepared?.warnings || [];
-}
-
-// 4. TIMINGS - Get performance metrics
-function get*Timings(prepared) {
-  return prepared?.timings || {};
-}
-
-export { prepare*, render*, get*Warnings, get*Timings };
-```
-
-### Creating a New Banner Type
-
-Create `src/banner/renderers/myBanner.js` following the 3-phase pattern:
-
-```javascript
-import { createCanvas } from '@napi-rs/canvas';
-import * as Background from '../components/background.js';
-import * as Certifications from '../components/certifications.js';
-
-const CANVAS_WIDTH = 1584;
-const CANVAS_HEIGHT = 396;
-
-async function generateMyBanner(data, options = {}) {
-  const canvas = createCanvas(CANVAS_WIDTH, CANVAS_HEIGHT);
-  const ctx = canvas.getContext('2d');
-
-  // PHASE 1: PREPARE (parallel when possible)
-  const [bgPrep, certsPrep] = await Promise.all([
-    Background.prepareBackground(options),
-    Certifications.prepareCertifications(data.certificationsData, options, {
-      availableWidth: CANVAS_WIDTH,
-      availableHeight: CANVAS_HEIGHT * 0.75,
-      spacing: 5,
-    }),
-  ]);
-
-  // PHASE 2: RENDER (sequential for correct layering)
-  await Background.renderBackground(ctx, bgPrep, CANVAS_WIDTH, CANVAS_HEIGHT);
-  await Certifications.renderCertifications(ctx, certsPrep, 0, 100);
-
-  // PHASE 3: COLLECT warnings and encode
-  const warnings = [
-    ...Background.getBackgroundWarnings(bgPrep),
-    ...Certifications.getCertificationsWarnings(certsPrep),
-  ];
-
-  return {
-    bannerUrl: `data:image/png;base64,${canvas.toBuffer('image/png').toString('base64')}`,
-    warnings,
-  };
-}
-```
-
-### Creating a New Component
-
-Create `src/banner/components/myComponent.js`:
-
-```javascript
-import { createCanvas, loadImage } from '@napi-rs/canvas';
-
-async function prepareMyComponent(data, options = {}, layout) {
-  const startTime = Date.now();
-  const warnings = [];
-
-  // Load assets, process data, calculate layout
-  // ...
-
-  return {
-    // Your data for rendering
-    warnings,
-    timings: { load_ms: Date.now() - startTime },
-  };
-}
-
-async function renderMyComponent(ctx, prepared, x, y) {
-  const startTime = Date.now();
-
-  // Use ctx.drawImage(), ctx.fillRect(), etc. to draw
-  // ...
-
-  return { render_ms: Date.now() - startTime };
-}
-
-function getMyComponentWarnings(prepared) {
-  return prepared?.warnings || [];
-}
-
-function getMyComponentTimings(prepared) {
-  return prepared?.timings || {};
-}
-
-export { prepareMyComponent, renderMyComponent, getMyComponentWarnings, getMyComponentTimings };
-```
-
-### Canvas & Drawing Best Practices
-
-**Module System:** Use ES6 modules (`import`/`export`) throughout
-
-**Canvas objects work as images** - No conversion needed:
-
-```javascript
-const canvas = createCanvas(width, height);
-ctx.drawImage(canvas, x, y); // ✅ Works directly
-```
-
-**Use CSS filters for effects**:
-
-```javascript
-// ✅ Correct - CSS filter
-const grayCtx = canvas.getContext('2d');
-grayCtx.filter = 'grayscale(100%)';
-grayCtx.drawImage(sourceImage, 0, 0);
-
-// ❌ Avoid - putImageData doesn't persist properly
-ctx.putImageData(modifiedImageData, x, y);
-```
-
-**Visual effects semantics**:
-
-- Expired certifications → Grayscale (action required)
-- Retired certifications → 50% opacity (not user's fault)
-
-### Layout Patterns
-
-**Fixed positions** for predictable elements:
-
-```javascript
-const counterX = 160;
-const agentblazerX = 370;
-```
-
-**Ratio-based positions** for responsive areas:
-
-```javascript
-const bottomAreaY = CANVAS_HEIGHT * TOP_PART_RATIO + 20;
-```
-
-**Layout constraints** passed to components:
-
-```javascript
-const layout = {
-  availableWidth: CANVAS_WIDTH,
-  availableHeight: CANVAS_HEIGHT * 0.75,
-  spacing: 5,
-};
-```
+> **Before writing banner code, read `docs/banner-components.md`** — full templates for new banner types and components, canvas best practices, and layout patterns.
 
 ### Common Pitfalls
 
@@ -378,4 +214,5 @@ const layout = {
 2. **Null-safe access**: `prepared?.width ?? 0` when reading dimensions
 3. **Validate URLs**: Block private IPs, check protocols (SSRF protection)
 4. **Check edge cases**: Division by zero when only 1 item exists
-5. **Module system**: Use ES6 (`import`/`export`) throughout
+5. **Visual semantics**: expired certifications → grayscale; retired → 50% opacity
+6. **Canvas**: ES6 modules throughout; canvas objects draw directly via `drawImage`; use CSS filters (`ctx.filter`), not `putImageData`

--- a/docs/banner-components.md
+++ b/docs/banner-components.md
@@ -1,0 +1,195 @@
+# Banner Component Architecture
+
+Full reference for the banner rendering system: component contract, templates for new banner types and components, canvas best practices, and layout patterns.
+
+## Banner Directory Structure
+
+```text
+src/banner/
+├── components/        # Reusable components (background, logos, certifications)
+│   ├── background.js
+│   ├── rankLogo.js
+│   ├── counters.js
+│   ├── certifications.js
+│   ├── superbadges.js
+│   ├── agentblazer.js
+│   ├── mvpRibbon.js
+│   └── watermark.js
+└── renderers/         # Banner implementations (standard, rewind, future types)
+    └── standardBanner.js
+```
+
+## Component Contract
+
+All components follow this 4-function pattern:
+
+```javascript
+// 1. PREPARE - Load assets, calculate layout (async, runs in parallel)
+async function prepare*(data, options = {}, layout) {
+  // Load images, process data, calculate positions
+  return { /* prepared data, warnings, timings */ };
+}
+
+// 2. RENDER - Draw to canvas (sequential for correct layering)
+async function render*(ctx, prepared, x, y) {
+  ctx.drawImage(...);  // Draw using prepared data
+  return { render_ms: timeElapsed };
+}
+
+// 3. WARNINGS - Get any issues encountered
+function get*Warnings(prepared) {
+  return prepared?.warnings || [];
+}
+
+// 4. TIMINGS - Get performance metrics
+function get*Timings(prepared) {
+  return prepared?.timings || {};
+}
+
+export { prepare*, render*, get*Warnings, get*Timings };
+```
+
+## Creating a New Banner Type
+
+Create `src/banner/renderers/myBanner.js` following the 3-phase pattern:
+
+```javascript
+import { createCanvas } from '@napi-rs/canvas';
+import * as Background from '../components/background.js';
+import * as Certifications from '../components/certifications.js';
+
+const CANVAS_WIDTH = 1584;
+const CANVAS_HEIGHT = 396;
+
+async function generateMyBanner(data, options = {}) {
+  const canvas = createCanvas(CANVAS_WIDTH, CANVAS_HEIGHT);
+  const ctx = canvas.getContext('2d');
+
+  // PHASE 1: PREPARE (parallel when possible)
+  const [bgPrep, certsPrep] = await Promise.all([
+    Background.prepareBackground(options),
+    Certifications.prepareCertifications(data.certificationsData, options, {
+      availableWidth: CANVAS_WIDTH,
+      availableHeight: CANVAS_HEIGHT * 0.75,
+      spacing: 5,
+    }),
+  ]);
+
+  // PHASE 2: RENDER (sequential for correct layering)
+  await Background.renderBackground(ctx, bgPrep, CANVAS_WIDTH, CANVAS_HEIGHT);
+  await Certifications.renderCertifications(ctx, certsPrep, 0, 100);
+
+  // PHASE 3: COLLECT warnings and encode
+  const warnings = [
+    ...Background.getBackgroundWarnings(bgPrep),
+    ...Certifications.getCertificationsWarnings(certsPrep),
+  ];
+
+  return {
+    bannerUrl: `data:image/png;base64,${canvas.toBuffer('image/png').toString('base64')}`,
+    warnings,
+  };
+}
+```
+
+## Creating a New Component
+
+Create `src/banner/components/myComponent.js`:
+
+```javascript
+import { createCanvas, loadImage } from '@napi-rs/canvas';
+
+async function prepareMyComponent(data, options = {}, layout) {
+  const startTime = Date.now();
+  const warnings = [];
+
+  // Load assets, process data, calculate layout
+  // ...
+
+  return {
+    // Your data for rendering
+    warnings,
+    timings: { load_ms: Date.now() - startTime },
+  };
+}
+
+async function renderMyComponent(ctx, prepared, x, y) {
+  const startTime = Date.now();
+
+  // Use ctx.drawImage(), ctx.fillRect(), etc. to draw
+  // ...
+
+  return { render_ms: Date.now() - startTime };
+}
+
+function getMyComponentWarnings(prepared) {
+  return prepared?.warnings || [];
+}
+
+function getMyComponentTimings(prepared) {
+  return prepared?.timings || {};
+}
+
+export { prepareMyComponent, renderMyComponent, getMyComponentWarnings, getMyComponentTimings };
+```
+
+## Canvas & Drawing Best Practices
+
+**Module System:** Use ES6 modules (`import`/`export`) throughout
+
+**Canvas objects work as images** - No conversion needed:
+
+```javascript
+const canvas = createCanvas(width, height);
+ctx.drawImage(canvas, x, y); // ✅ Works directly
+```
+
+**Use CSS filters for effects**:
+
+```javascript
+// ✅ Correct - CSS filter
+const grayCtx = canvas.getContext('2d');
+grayCtx.filter = 'grayscale(100%)';
+grayCtx.drawImage(sourceImage, 0, 0);
+
+// ❌ Avoid - putImageData doesn't persist properly
+ctx.putImageData(modifiedImageData, x, y);
+```
+
+**Visual effects semantics**:
+
+- Expired certifications → Grayscale (action required)
+- Retired certifications → 50% opacity (not user's fault)
+
+## Layout Patterns
+
+**Fixed positions** for predictable elements:
+
+```javascript
+const counterX = 160;
+const agentblazerX = 370;
+```
+
+**Ratio-based positions** for responsive areas:
+
+```javascript
+const bottomAreaY = CANVAS_HEIGHT * TOP_PART_RATIO + 20;
+```
+
+**Layout constraints** passed to components:
+
+```javascript
+const layout = {
+  availableWidth: CANVAS_WIDTH,
+  availableHeight: CANVAS_HEIGHT * 0.75,
+  spacing: 5,
+};
+```
+
+## Common Pitfalls
+
+1. **Always use default parameters**: `options = {}` prevents undefined errors
+2. **Null-safe access**: `prepared?.width ?? 0` when reading dimensions
+3. **Validate URLs**: Block private IPs, check protocols (SSRF protection)
+4. **Check edge cases**: Division by zero when only 1 item exists
+5. **Module system**: Use ES6 (`import`/`export`) throughout


### PR DESCRIPTION
## Summary

Improvements to the Claude Code setup after an audit of `.claude/`:

- **Register hooks** — `SessionStart.sh` and `PreCompact.sh` existed but were never registered in `settings.json`, so they never ran. Now wired up.
- **Remove stale agent model pins** — both agents pinned `claude-sonnet-4-6` (two generations old); they now inherit the session model.
- **Add `/verify` skill** — end-to-end check composing existing skills: production build → fresh dev server → banner generation via `POST /api/banner/standard` (per username, default `nabondance`) → PASS/FAIL summary. Tested locally: `Verify: PASS`.
- **Slim CLAUDE.md** (12.4KB → ~9.5KB always-loaded) — full banner component templates moved to `docs/banner-components.md`, replaced by a compact contract summary + pointer.
- **New CLAUDE.md sections** — *Verifying Changes* (when to use `/verify` vs `/dev-start` + `/img-test`) and *Working Docs* (points sessions at `docs/`).

## Test plan

- [x] `bash .claude/skills/verify.sh` passes end-to-end (build + banner generation)
- [x] Both hook scripts dry-run cleanly
- [x] `settings.json` valid JSON
- [x] Prettier clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)