### PR TITLE
fix(ci): repair automated release-to-deploy chain

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -17,9 +17,13 @@ on:
         description: 'Release notes (optional)'
         required: false
         type: string
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - closed
+
+concurrency:
+  group: automated-release
+  cancel-in-progress: false
 
 jobs:
   create-release:
@@ -111,8 +115,8 @@ jobs:
         id: create_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          RELEASE_NOTES="${{ github.event.inputs.release_notes }}"
           if [ -z "$RELEASE_NOTES" ]; then
             RELEASE_NOTES="Automated release v${{ steps.new_version.outputs.version }}"
           fi
@@ -149,8 +153,8 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          RELEASE_NOTES="${{ github.event.inputs.release_notes }}"
           if [ -z "$RELEASE_NOTES" ]; then
             RELEASE_NOTES="Automated release v${{ steps.new_version.outputs.version }}"
           fi
@@ -158,7 +162,7 @@ jobs:
           # Generate changelog from commits since last release
           LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log "$LAST_TAG..HEAD" --oneline --pretty=format:"- %s" | grep -v "^- Merge pull request" | head -20)
+            CHANGELOG=$(git log "$LAST_TAG..HEAD" --oneline --pretty=format:"- %s" | grep -v "^- Merge pull request" | head -20 || true)
             CHANGELOG_URL="**Full Changelog**: https://github.com/nabondance/Trailhead-Banner/compare/$LAST_TAG...${{ steps.new_version.outputs.tag }}"
           else
             CHANGELOG="- Initial release"
@@ -218,15 +222,25 @@ jobs:
             echo "2. Merge the PR to publish the release and trigger deployment"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # This job runs after the release PR is merged to publish the release
+  # This job runs after the release PR is merged to publish the release.
+  # Gated on the "release" label so it is independent of the merge strategy
+  # (merge commit / squash / rebase).
   publish-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'release:')
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+    outputs:
+      published: ${{ steps.check_release.outputs.exists }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Get version from package.json
         id: version
@@ -253,5 +267,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "${{ steps.version.outputs.tag }}" --draft=false
+          # Retarget the tag onto the merged commit on main (the release
+          # branch may already be deleted after merge).
+          gh release edit "${{ steps.version.outputs.tag }}" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --draft=false
           echo "✅ Release v${{ steps.version.outputs.version }} has been published!"
+
+  # Deploy to production by calling the reusable deployment workflow directly.
+  # This avoids relying on the tag push (a tag created with GITHUB_TOKEN does
+  # not trigger the push-based deployment workflow).
+  deploy-production:
+    needs: publish-release
+    if: needs.publish-release.outputs.published == 'true'
+    uses: ./.github/workflows/production-deployment.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -279,7 +279,9 @@ jobs:
   # not trigger the push-based deployment workflow).
   deploy-production:
     needs: publish-release
-    if: needs.publish-release.outputs.published == 'true'
+    if: >-
+      needs.publish-release.result == 'success' &&
+      needs.publish-release.outputs.published == 'true'
     uses: ./.github/workflows/production-deployment.yml
     secrets: inherit
     with:

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -7,12 +7,20 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (commit SHA) to deploy. Defaults to the triggering ref.'
+        required: false
+        type: string
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,5 +1,5 @@
 ---
-name: Production Deployment by tag
+name: Production Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## What & why

The automated release workflow created a PR and a draft release, but the **release→deploy chain was broken in two independent places**, so merging a release PR neither reliably published the release nor deployed to production.

### Fixes

- **Deploy no longer relies on the tag push (no PAT needed).** A tag created with `GITHUB_TOKEN` does not trigger `push: tags` workflows, so production never deployed. `production-deployment.yml` is now a **reusable workflow** (`workflow_call`, optional `ref` input) and is called directly by a new `deploy-production` job.
- **Publish gate is now merge-strategy-proof.** Switched from matching the `release:` merge-commit message (which fails on merge-commit/squash) to `pull_request: closed` + the **`release` label**.
- **Tag retargeted to the merged commit** (`merge_commit_sha`) so it stays valid even after the release branch is deleted.
- **Shell-injection fix:** `release_notes` is passed via `env:` instead of inlined into the run script.
- **Hardening:** added a `concurrency` group; explicit success gate on `deploy-production` (`result == 'success' && published == 'true'`); robust changelog `grep` pipeline; renamed the deploy workflow to "Production Deployment".

### New flow

Dispatch → PR + draft release → merge the `release`-labeled PR → `publish-release` un-drafts + tags the merged commit → `deploy-production` calls the Vercel deploy directly.

## Notes / behavior changes

- The workflow now runs (and immediately skips both jobs) on **every closed PR** — unavoidable with a label gate; cosmetic.
- The reusable deploy keeps `environment: production`; if that environment requires reviewers, each release deploy pauses for approval (tag/release already published at that point).
- Static review only — `actionlint` wasn't available locally; MegaLinter runs it in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)