### PR TITLE
fix(ci): list grouped PRs and use vX.Y.Z title in releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# Configuration for GitHub's automatically generated release notes.
+#
+# Consumed by the "Create Draft Release" step in
+# .github/workflows/automated-release.yml (POST /releases/generate-notes),
+# which lists merged pull requests grouped into the categories below.
+#
+# Matching notes:
+# - A PR lands in the first category it matches.
+# - "What's Changed" is the catch-all (labels: '*') minus dependency PRs, so it
+#   is listed first while still leaving dependency bumps for the second group.
+# - npm dependabot PRs carry the `dependencies` label; github-actions dependabot
+#   PRs carry `github_actions` (the labeler's sync-labels strips `dependencies`
+#   from them). Matching both catches every dependency PR, plus manual ones.
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+          - github_actions
+    - title: Dependencies
+      labels:
+        - dependencies
+        - github_actions

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -153,45 +153,51 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          if [ -z "$RELEASE_NOTES" ]; then
-            RELEASE_NOTES="Automated release v${{ steps.new_version.outputs.version }}"
-          fi
-
-          # Generate changelog from commits since last release
+          # Find the previous release tag (HEAD is the version-bump commit).
           LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          # Generate PR-based release notes via GitHub's API. This lists the
+          # merged pull requests since the last release (instead of raw commits)
+          # and honours .github/release.yml categorisation. The "Full Changelog"
+          # link is appended automatically.
           if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log "$LAST_TAG..HEAD" --oneline --pretty=format:"- %s" | grep -v "^- Merge pull request" | head -20 || true)
-            CHANGELOG_URL="**Full Changelog**: https://github.com/nabondance/Trailhead-Banner/compare/$LAST_TAG...${{ steps.new_version.outputs.tag }}"
+            CHANGELOG=$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="${{ steps.new_version.outputs.tag }}" \
+              -f target_commitish="${{ steps.new_version.outputs.branch }}" \
+              -f previous_tag_name="$LAST_TAG" \
+              --jq '.body')
           else
-            CHANGELOG="- Initial release"
-            CHANGELOG_URL=""
+            CHANGELOG=$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="${{ steps.new_version.outputs.tag }}" \
+              -f target_commitish="${{ steps.new_version.outputs.branch }}" \
+              --jq '.body')
           fi
 
-          RELEASE_BODY="
+          RELEASE_BODY=$(cat <<EOF
           <!-- display-start -->
           # Features
           -  ...
           <!-- display-end -->
 
-          ## What's Changed
-
-          $RELEASE_NOTES
-
-          ### Commits
           $CHANGELOG
 
-          $CHANGELOG_URL
-
           ---
-          *This release was created automatically. It will be published when the release PR is merged.*"
+          *This release was created automatically. It will be published when the release PR is merged.*
+          EOF
+          )
 
-          RELEASE_URL=$(gh release create ${{ steps.new_version.outputs.tag }} \
-            --title "Release v${{ steps.new_version.outputs.version }}" \
+          RELEASE_URL=$(gh release create "${{ steps.new_version.outputs.tag }}" \
+            --title "${{ steps.new_version.outputs.tag }}" \
             --notes "$RELEASE_BODY" \
             --draft \
-            --target ${{ steps.new_version.outputs.branch }})
+            --target "${{ steps.new_version.outputs.branch }}")
 
           echo "url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What's Changed

Restores the historical release convention that the recent release-management rework had regressed, and adds automatic PR grouping.

### Release notes: PRs instead of commits
The *Create Draft Release* step now generates notes via the GitHub `releases/generate-notes` API, listing **merged pull requests** (`* title by @author in <PR-url>`) instead of raw `git log` commits — matching how `v1.17.0`–`v1.21.0` looked. The **Full Changelog** link is appended automatically.

### Release title
`Release vX.Y.Z` → **`vX.Y.Z`**, consistent with every prior release.

### Grouped notes (`.github/release.yml`, new)
Auto-groups the generated notes into:

- **What's Changed** — all non-dependency PRs (listed first)
- **Dependencies** — dependabot npm + github-actions bumps, plus manual dep PRs

Matches both the `dependencies` label (npm) and `github_actions` label (actions), because the labeler's `sync-labels: true` strips `dependencies` from github-actions bumps.

> Grouping reads `release.yml` from the branch being released, so it takes effect for releases cut **after** this merges to `main`.

### Preserved
The `<!-- display-start -->` **Features** block is untouched — the `/releases` page extracts only that block for display (`src/utils/releasesUtils.js`). Only the section *below* the markers changed (commits → grouped PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)